### PR TITLE
feat: add debug purchase confirmation flow

### DIFF
--- a/thecode_pie_app/lib/core/constants/app_constants.dart
+++ b/thecode_pie_app/lib/core/constants/app_constants.dart
@@ -43,6 +43,12 @@ class AppConstants {
   static String hintAccessEndpoint(int episodeId, int stageNo) =>
       '$baseUrl$apiVersion/commerce/hint-access/$episodeId/$stageNo/';
 
+  static String get entitlementStatusEndpoint =>
+      '$baseUrl$apiVersion/commerce/entitlements/';
+
+  static String get googlePlayPurchaseVerifyEndpoint =>
+      '$baseUrl$apiVersion/commerce/purchases/google/verify/';
+
   /// s3://bucket/key 형태를 HTTPS public URL로 변환
   /// - 이미 http/https 이면 그대로 반환
   /// - 변환 실패 시 원문 반환

--- a/thecode_pie_app/lib/core/purchase/purchase_api.dart
+++ b/thecode_pie_app/lib/core/purchase/purchase_api.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:thecode_pie_app/auth/data/repository/auth_repository.dart';
+import 'package:thecode_pie_app/core/constants/app_constants.dart';
+import 'package:thecode_pie_app/core/purchase/purchase_product.dart';
+
+class PurchaseEntitlements {
+  const PurchaseEntitlements({
+    required this.hintAdRemoved,
+    required this.bannerAdRemoved,
+    required this.stageUnlocked,
+  });
+
+  final bool hintAdRemoved;
+  final bool bannerAdRemoved;
+  final bool stageUnlocked;
+
+  factory PurchaseEntitlements.empty() {
+    return const PurchaseEntitlements(
+      hintAdRemoved: false,
+      bannerAdRemoved: false,
+      stageUnlocked: false,
+    );
+  }
+
+  factory PurchaseEntitlements.fromJson(Map<String, dynamic> json) {
+    return PurchaseEntitlements(
+      hintAdRemoved: json['hint_ad_removed'] == true,
+      bannerAdRemoved: json['banner_ad_removed'] == true,
+      stageUnlocked: json['stage_unlocked'] == true,
+    );
+  }
+
+  PurchaseEntitlements copyWith({
+    bool? hintAdRemoved,
+    bool? bannerAdRemoved,
+    bool? stageUnlocked,
+  }) {
+    return PurchaseEntitlements(
+      hintAdRemoved: hintAdRemoved ?? this.hintAdRemoved,
+      bannerAdRemoved: bannerAdRemoved ?? this.bannerAdRemoved,
+      stageUnlocked: stageUnlocked ?? this.stageUnlocked,
+    );
+  }
+}
+
+class PurchaseApi {
+  PurchaseApi(this._authRepository);
+
+  final AuthRepository _authRepository;
+
+  Future<PurchaseEntitlements> fetchEntitlements() async {
+    final response = await _authRepository.makeAuthenticatedRequest(
+      (accessToken) => http.get(
+        Uri.parse(AppConstants.entitlementStatusEndpoint),
+        headers: {'Authorization': 'Bearer $accessToken'},
+      ),
+    );
+    return _parseEntitlements(response);
+  }
+
+  Future<PurchaseEntitlements> verifyGooglePlayPurchase({
+    required PurchaseProduct product,
+    required String purchaseToken,
+  }) async {
+    final response = await _authRepository.makeAuthenticatedRequest(
+      (accessToken) => http.post(
+        Uri.parse(AppConstants.googlePlayPurchaseVerifyEndpoint),
+        headers: {
+          'Authorization': 'Bearer $accessToken',
+          'Content-Type': 'application/json',
+        },
+        body: jsonEncode({
+          'product_id': product.productId,
+          'purchase_token': purchaseToken,
+        }),
+      ),
+    );
+    return _parseEntitlements(response);
+  }
+
+  PurchaseEntitlements _parseEntitlements(http.Response response) {
+    final decoded = jsonDecode(utf8.decode(response.bodyBytes));
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      final message = decoded is Map<String, dynamic>
+          ? decoded['message']?.toString()
+          : null;
+      throw Exception(message ?? 'Purchase request failed.');
+    }
+
+    if (decoded is! Map<String, dynamic>) {
+      throw Exception('Invalid purchase response.');
+    }
+
+    final data = decoded['data'];
+    if (data is! Map<String, dynamic>) {
+      throw Exception('Purchase response data is missing.');
+    }
+
+    return PurchaseEntitlements.fromJson(data);
+  }
+}

--- a/thecode_pie_app/lib/core/purchase/purchase_product.dart
+++ b/thecode_pie_app/lib/core/purchase/purchase_product.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+enum PurchaseProduct {
+  premium(
+    productId: 'premium_package',
+    title: '프리미엄 패키지',
+    fallbackPrice: '₩3,990',
+    icon: Icons.workspace_premium_rounded,
+    benefits: ['힌트 광고 제거', '배너 광고 제거', 'STAGE 21-50 추가 해금'],
+  ),
+  stageUnlock(
+    productId: 'stage_unlock',
+    title: 'STAGE 해금',
+    fallbackPrice: '₩2,990',
+    icon: Icons.lock_open_rounded,
+    benefits: ['STAGE 21-50 추가 해금'],
+  ),
+  adRemoval(
+    productId: 'remove_ads',
+    title: '광고 제거',
+    fallbackPrice: '₩1,490',
+    icon: Icons.block_rounded,
+    benefits: ['힌트 광고 제거', '배너 광고 제거'],
+  );
+
+  const PurchaseProduct({
+    required this.productId,
+    required this.title,
+    required this.fallbackPrice,
+    required this.icon,
+    required this.benefits,
+  });
+
+  final String productId;
+  final String title;
+  final String fallbackPrice;
+  final IconData icon;
+  final List<String> benefits;
+
+  static PurchaseProduct? fromProductId(String productId) {
+    for (final product in values) {
+      if (product.productId == productId) return product;
+    }
+    return null;
+  }
+}

--- a/thecode_pie_app/lib/presentation/component/google_login_button.dart
+++ b/thecode_pie_app/lib/presentation/component/google_login_button.dart
@@ -45,7 +45,7 @@ class GoogleLoginButton extends StatelessWidget {
                     GoogleMark(),
                     SizedBox(width: 10),
                     Text(
-                      '시작하기',
+                      'Google로 시작하기',
                       style: TextStyle(
                         fontFamily: AppFonts.body,
                         fontSize: 15,

--- a/thecode_pie_app/lib/presentation/component/premium_purchase_dialog.dart
+++ b/thecode_pie_app/lib/presentation/component/premium_purchase_dialog.dart
@@ -1,56 +1,12 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:thecode_pie_app/core/constants/app_colors.dart';
 import 'package:thecode_pie_app/core/constants/app_fonts.dart';
+import 'package:thecode_pie_app/core/purchase/purchase_product.dart';
+import 'package:thecode_pie_app/presentation/purchase/purchase_view_model.dart';
 
-enum PurchaseProduct {
-  premium,
-  stageUnlock,
-  adRemoval;
-
-  String get title {
-    switch (this) {
-      case PurchaseProduct.premium:
-        return '프리미엄 패키지';
-      case PurchaseProduct.stageUnlock:
-        return 'STAGE 해금';
-      case PurchaseProduct.adRemoval:
-        return '광고 제거만 구매';
-    }
-  }
-
-  String get buttonText {
-    switch (this) {
-      case PurchaseProduct.premium:
-        return '₩ 3,990원';
-      case PurchaseProduct.stageUnlock:
-        return '₩ 2,990원';
-      case PurchaseProduct.adRemoval:
-        return '₩ 1,490원';
-    }
-  }
-
-  IconData get icon {
-    switch (this) {
-      case PurchaseProduct.premium:
-        return Icons.workspace_premium_rounded;
-      case PurchaseProduct.stageUnlock:
-        return Icons.lock_open_rounded;
-      case PurchaseProduct.adRemoval:
-        return Icons.block_rounded;
-    }
-  }
-
-  List<String> get benefits {
-    switch (this) {
-      case PurchaseProduct.premium:
-        return const ['힌트 무제한 제공', '광고 제거', 'STAGE 21-50 추가 해금'];
-      case PurchaseProduct.stageUnlock:
-        return const ['STAGE 21-50 추가 해금'];
-      case PurchaseProduct.adRemoval:
-        return const ['광고 제거'];
-    }
-  }
-}
+export 'package:thecode_pie_app/core/purchase/purchase_product.dart';
 
 class PremiumPurchaseDialog extends StatelessWidget {
   const PremiumPurchaseDialog({
@@ -83,80 +39,161 @@ class PremiumPurchaseDialog extends StatelessWidget {
               ),
             ],
           ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Row(
+          child: Consumer<PurchaseViewModel>(
+            builder: (context, purchaseViewModel, _) {
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  const SizedBox(width: 34),
-                  const Expanded(
-                    child: Text(
-                      '구매하기',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontFamily: AppFonts.title,
-                        fontSize: 24,
-                        fontWeight: FontWeight.w700,
-                        color: AppColors.crust,
+                  Row(
+                    children: [
+                      const SizedBox(width: 34),
+                      const Expanded(
+                        child: Text(
+                          '구매하기',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            fontFamily: AppFonts.title,
+                            fontSize: 24,
+                            fontWeight: FontWeight.w700,
+                            color: AppColors.crust,
+                          ),
+                        ),
+                      ),
+                      Transform.translate(
+                        offset: const Offset(8, 0),
+                        child: IconButton(
+                          onPressed: () => Navigator.of(context).pop(),
+                          icon: const Icon(Icons.close_rounded, size: 22),
+                          color: AppColors.crust,
+                          tooltip: '닫기',
+                          padding: EdgeInsets.zero,
+                          constraints: const BoxConstraints(
+                            minWidth: 34,
+                            minHeight: 34,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  if (!isPremium) ...[
+                    _PurchaseCard(
+                      product: PurchaseProduct.premium,
+                      buttonText: purchaseViewModel.priceLabel(
+                        PurchaseProduct.premium,
+                      ),
+                      emphasized: true,
+                      isOwned: purchaseViewModel.isOwned(
+                        PurchaseProduct.premium,
+                      ),
+                      isBusy: purchaseViewModel.isPurchasing,
+                      onPressed: () => _handlePurchasePressed(
+                        context,
+                        purchaseViewModel,
+                        PurchaseProduct.premium,
                       ),
                     ),
+                    const SizedBox(height: 12),
+                  ],
+                  _PurchaseCard(
+                    product: product,
+                    buttonText: purchaseViewModel.priceLabel(product),
+                    emphasized: isPremium,
+                    isOwned: purchaseViewModel.isOwned(product),
+                    isBusy: purchaseViewModel.isPurchasing,
+                    onPressed: () => _handlePurchasePressed(
+                      context,
+                      purchaseViewModel,
+                      product,
+                    ),
                   ),
-                  Transform.translate(
-                    offset: const Offset(8, 0),
-                    child: IconButton(
-                      onPressed: () => Navigator.of(context).pop(),
-                      icon: const Icon(Icons.close_rounded, size: 22),
-                      color: AppColors.crust,
-                      tooltip: '닫기',
-                      padding: EdgeInsets.zero,
-                      constraints: const BoxConstraints(
-                        minWidth: 34,
-                        minHeight: 34,
+                  if (purchaseViewModel.errorMessage != null) ...[
+                    const SizedBox(height: 10),
+                    Text(
+                      purchaseViewModel.errorMessage!,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        fontFamily: AppFonts.body,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                        color: AppColors.plum,
+                      ),
+                    ),
+                  ],
+                  const SizedBox(height: 8),
+                  TextButton(
+                    onPressed: purchaseViewModel.isPurchasing
+                        ? null
+                        : purchaseViewModel.restorePurchases,
+                    child: const Text(
+                      '구매 복원',
+                      style: TextStyle(
+                        fontFamily: AppFonts.body,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w800,
+                        color: AppColors.textTertiary,
                       ),
                     ),
                   ),
                 ],
-              ),
-              const SizedBox(height: 16),
-              if (!isPremium) ...[
-                _PurchaseCard(
-                  title: PurchaseProduct.premium.title,
-                  buttonText: PurchaseProduct.premium.buttonText,
-                  icon: PurchaseProduct.premium.icon,
-                  benefits: PurchaseProduct.premium.benefits,
-                  emphasized: true,
-                ),
-                const SizedBox(height: 12),
-              ],
-              _PurchaseCard(
-                title: product.title,
-                buttonText: product.buttonText,
-                icon: product.icon,
-                benefits: product.benefits,
-                emphasized: isPremium,
-              ),
-            ],
+              );
+            },
           ),
         ),
       ),
     );
   }
+
+  Future<void> _handlePurchasePressed(
+    BuildContext context,
+    PurchaseViewModel purchaseViewModel,
+    PurchaseProduct product,
+  ) async {
+    if (!kDebugMode) {
+      await purchaseViewModel.buy(product);
+      return;
+    }
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('테스트 구매'),
+        content: Text('${product.title}\n테스트용으로 구매 확정하시겠습니까?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('아니오'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('예'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      purchaseViewModel.applyDebugPurchase(product);
+    }
+  }
 }
 
 class _PurchaseCard extends StatelessWidget {
   const _PurchaseCard({
-    required this.title,
+    required this.product,
     required this.buttonText,
-    required this.icon,
-    required this.benefits,
+    required this.isOwned,
+    required this.isBusy,
+    required this.onPressed,
     this.emphasized = false,
   });
 
-  final String title;
+  final PurchaseProduct product;
   final String buttonText;
-  final IconData icon;
-  final List<String> benefits;
+  final bool isOwned;
+  final bool isBusy;
+  final VoidCallback onPressed;
   final bool emphasized;
 
   @override
@@ -182,14 +219,14 @@ class _PurchaseCard extends StatelessWidget {
           Row(
             children: [
               Icon(
-                icon,
+                product.icon,
                 color: emphasized ? gold : AppColors.textTertiary,
                 size: 22,
               ),
               const SizedBox(width: 9),
               Expanded(
                 child: Text(
-                  title,
+                  product.title,
                   style: TextStyle(
                     fontFamily: AppFonts.body,
                     fontSize: emphasized ? 15 : 14,
@@ -221,18 +258,24 @@ class _PurchaseCard extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 9),
-          for (final benefit in benefits) ...[
+          for (final benefit in product.benefits) ...[
             _PremiumBenefit(text: benefit),
-            if (benefit != benefits.last) const SizedBox(height: 5),
+            if (benefit != product.benefits.last) const SizedBox(height: 5),
           ],
           const SizedBox(height: 10),
           SizedBox(
             height: emphasized ? 46 : 40,
             child: ElevatedButton(
-              onPressed: () {},
+              onPressed: isOwned || isBusy ? null : onPressed,
               style: ElevatedButton.styleFrom(
                 backgroundColor: emphasized ? gold : AppColors.crust,
+                disabledBackgroundColor: AppColors.textTertiary.withValues(
+                  alpha: 0.28,
+                ),
                 foregroundColor: AppColors.textOnPumpkin,
+                disabledForegroundColor: AppColors.textOnPumpkin.withValues(
+                  alpha: 0.72,
+                ),
                 elevation: 0,
                 textStyle: const TextStyle(
                   fontFamily: AppFonts.body,
@@ -243,7 +286,7 @@ class _PurchaseCard extends StatelessWidget {
                   borderRadius: BorderRadius.circular(8),
                 ),
               ),
-              child: Text(buttonText),
+              child: Text(isOwned ? '구매 완료' : buttonText),
             ),
           ),
         ],

--- a/thecode_pie_app/lib/presentation/purchase/purchase_view_model.dart
+++ b/thecode_pie_app/lib/presentation/purchase/purchase_view_model.dart
@@ -1,0 +1,230 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:thecode_pie_app/core/purchase/purchase_api.dart';
+import 'package:thecode_pie_app/core/purchase/purchase_product.dart';
+
+class PurchaseViewModel extends ChangeNotifier {
+  PurchaseViewModel({
+    required PurchaseApi purchaseApi,
+    InAppPurchase? inAppPurchase,
+  }) : _purchaseApi = purchaseApi,
+       _inAppPurchase = inAppPurchase ?? InAppPurchase.instance;
+
+  final PurchaseApi _purchaseApi;
+  final InAppPurchase _inAppPurchase;
+  StreamSubscription<List<PurchaseDetails>>? _purchaseSubscription;
+
+  final Map<String, ProductDetails> _storeProducts = {};
+  PurchaseEntitlements _entitlements = PurchaseEntitlements.empty();
+
+  bool _isAvailable = false;
+  bool _isLoading = false;
+  bool _isPurchasing = false;
+  String? _errorMessage;
+
+  bool get isAvailable => _isAvailable;
+  bool get isLoading => _isLoading;
+  bool get isPurchasing => _isPurchasing;
+  String? get errorMessage => _errorMessage;
+
+  bool get skipsHintAds => _entitlements.hintAdRemoved;
+  bool get removesAds =>
+      _entitlements.hintAdRemoved && _entitlements.bannerAdRemoved;
+  bool get unlocksPremiumStages => _entitlements.stageUnlocked;
+  bool get hasAnyEntitlement =>
+      skipsHintAds || removesAds || unlocksPremiumStages;
+
+  bool isOwned(PurchaseProduct product) {
+    switch (product) {
+      case PurchaseProduct.premium:
+        return skipsHintAds && removesAds && unlocksPremiumStages;
+      case PurchaseProduct.stageUnlock:
+        return unlocksPremiumStages;
+      case PurchaseProduct.adRemoval:
+        return removesAds;
+    }
+  }
+
+  String priceLabel(PurchaseProduct product) {
+    return _storeProducts[product.productId]?.price ?? product.fallbackPrice;
+  }
+
+  Future<void> initialize() async {
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    _purchaseSubscription ??= _inAppPurchase.purchaseStream.listen(
+      _handlePurchaseUpdates,
+      onError: (Object error) {
+        _isPurchasing = false;
+        _errorMessage = error.toString();
+        notifyListeners();
+      },
+    );
+
+    await syncEntitlements();
+    await loadProducts();
+  }
+
+  Future<void> syncEntitlements() async {
+    try {
+      _entitlements = await _purchaseApi.fetchEntitlements();
+    } catch (e) {
+      debugPrint('[Purchase] entitlement sync failed: $e');
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadProducts() async {
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      _isAvailable = await _inAppPurchase.isAvailable();
+      if (!_isAvailable) {
+        _isLoading = false;
+        _errorMessage = '결제를 사용할 수 없습니다.';
+        notifyListeners();
+        return;
+      }
+
+      final response = await _inAppPurchase.queryProductDetails(
+        PurchaseProduct.values.map((product) => product.productId).toSet(),
+      );
+
+      _storeProducts
+        ..clear()
+        ..addEntries(
+          response.productDetails.map(
+            (details) => MapEntry(details.id, details),
+          ),
+        );
+
+      if (response.notFoundIDs.isNotEmpty) {
+        debugPrint('[Purchase] products not found: ${response.notFoundIDs}');
+      }
+    } catch (e) {
+      _errorMessage = e.toString();
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> buy(PurchaseProduct product) async {
+    final details = _storeProducts[product.productId];
+    if (details == null) {
+      _errorMessage = '상품 정보를 불러오지 못했습니다.';
+      notifyListeners();
+      await loadProducts();
+      return;
+    }
+
+    _isPurchasing = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    final param = PurchaseParam(productDetails: details);
+    await _inAppPurchase.buyNonConsumable(purchaseParam: param);
+  }
+
+  Future<void> restorePurchases() async {
+    _isPurchasing = true;
+    _errorMessage = null;
+    notifyListeners();
+    await _inAppPurchase.restorePurchases();
+  }
+
+  void applyDebugPurchase(PurchaseProduct product) {
+    if (!kDebugMode) return;
+
+    switch (product) {
+      case PurchaseProduct.premium:
+        _entitlements = _entitlements.copyWith(
+          hintAdRemoved: true,
+          bannerAdRemoved: true,
+          stageUnlocked: true,
+        );
+      case PurchaseProduct.stageUnlock:
+        _entitlements = _entitlements.copyWith(stageUnlocked: true);
+      case PurchaseProduct.adRemoval:
+        _entitlements = _entitlements.copyWith(
+          hintAdRemoved: true,
+          bannerAdRemoved: true,
+        );
+    }
+
+    _errorMessage = null;
+    notifyListeners();
+  }
+
+  void resetDebugPurchases() {
+    if (!kDebugMode) return;
+
+    _entitlements = PurchaseEntitlements.empty();
+    _errorMessage = null;
+    notifyListeners();
+  }
+
+  Future<void> _handlePurchaseUpdates(
+    List<PurchaseDetails> purchaseDetailsList,
+  ) async {
+    for (final purchaseDetails in purchaseDetailsList) {
+      var shouldComplete = false;
+      switch (purchaseDetails.status) {
+        case PurchaseStatus.pending:
+          _isPurchasing = true;
+          break;
+        case PurchaseStatus.purchased:
+        case PurchaseStatus.restored:
+          shouldComplete = await _verifyAndSyncEntitlements(purchaseDetails);
+          _isPurchasing = false;
+          break;
+        case PurchaseStatus.error:
+          _isPurchasing = false;
+          _errorMessage = purchaseDetails.error?.message ?? '결제에 실패했습니다.';
+          shouldComplete = true;
+          break;
+        case PurchaseStatus.canceled:
+          _isPurchasing = false;
+          shouldComplete = true;
+          break;
+      }
+
+      if (shouldComplete && purchaseDetails.pendingCompletePurchase) {
+        await _inAppPurchase.completePurchase(purchaseDetails);
+      }
+    }
+
+    notifyListeners();
+  }
+
+  Future<bool> _verifyAndSyncEntitlements(
+    PurchaseDetails purchaseDetails,
+  ) async {
+    final product = PurchaseProduct.fromProductId(purchaseDetails.productID);
+    if (product == null) return false;
+
+    try {
+      _entitlements = await _purchaseApi.verifyGooglePlayPurchase(
+        product: product,
+        purchaseToken: purchaseDetails.verificationData.serverVerificationData,
+      );
+      return true;
+    } catch (e) {
+      _errorMessage = e.toString();
+      return false;
+    }
+  }
+
+  @override
+  void dispose() {
+    _purchaseSubscription?.cancel();
+    super.dispose();
+  }
+}

--- a/thecode_pie_app/lib/presentation/screen/auth/auth_screen.dart
+++ b/thecode_pie_app/lib/presentation/screen/auth/auth_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:thecode_pie_app/core/constants/app_colors.dart';
@@ -6,6 +7,7 @@ import 'package:thecode_pie_app/core/constants/app_fonts.dart';
 import 'package:thecode_pie_app/presentation/component/google_login_button.dart';
 import 'package:thecode_pie_app/presentation/component/retro_background.dart';
 import 'package:thecode_pie_app/presentation/component/settings_button.dart';
+import 'package:thecode_pie_app/presentation/purchase/purchase_view_model.dart';
 
 import '../../../providers/app_providers.dart';
 import '../quiz/quiz_screen_root.dart';
@@ -39,12 +41,12 @@ class LoginScreen extends StatelessWidget {
                     ),
                   ),
                 ),
-                Positioned(top: 10, right: 10, child: const SettingsButton()),
+                const Positioned(top: 10, right: 10, child: SettingsButton()),
                 Positioned(
                   right: 20,
                   bottom: 14,
                   child: Text(
-                    '© 2026 Clavis',
+                    '2026 Clavis',
                     style: TextStyle(
                       fontFamily: AppFonts.body,
                       fontSize: 11,
@@ -54,6 +56,39 @@ class LoginScreen extends StatelessWidget {
                     ),
                   ),
                 ),
+                if (kDebugMode)
+                  Positioned(
+                    left: 20,
+                    bottom: 10,
+                    child: Consumer<PurchaseViewModel>(
+                      builder: (context, purchaseViewModel, _) {
+                        if (!purchaseViewModel.hasAnyEntitlement) {
+                          return const SizedBox.shrink();
+                        }
+
+                        return TextButton(
+                          onPressed: purchaseViewModel.resetDebugPurchases,
+                          style: TextButton.styleFrom(
+                            minimumSize: const Size(0, 34),
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 10,
+                              vertical: 6,
+                            ),
+                            foregroundColor: AppColors.textOnPumpkin,
+                            textStyle: const TextStyle(
+                              fontFamily: AppFonts.body,
+                              fontSize: 11,
+                              fontWeight: FontWeight.w800,
+                            ),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                          ),
+                          child: const Text('구매 초기화'),
+                        );
+                      },
+                    ),
+                  ),
                 Center(
                   child: Transform.translate(
                     offset: const Offset(0, -24),
@@ -171,7 +206,9 @@ class LoginScreen extends StatelessWidget {
     BuildContext context,
     AuthViewModel viewModel,
   ) async {
-    await viewModel.signInWithGoogle();
+    final signedIn = await viewModel.signInWithGoogle();
+    if (!context.mounted || !signedIn) return;
+    await context.read<PurchaseViewModel>().syncEntitlements();
   }
 
   Future<void> _handleStartButton(

--- a/thecode_pie_app/lib/presentation/screen/quiz/quiz_screen.dart
+++ b/thecode_pie_app/lib/presentation/screen/quiz/quiz_screen.dart
@@ -15,6 +15,7 @@ import '../../component/premium_purchase_dialog.dart';
 import '../../component/quiz_image.dart';
 import '../../component/settings_button.dart';
 import '../auth/auth_view_model.dart';
+import '../../purchase/purchase_view_model.dart';
 import 'quiz_view_model.dart';
 import 'quiz_screen_root.dart';
 import '../../../providers/app_providers.dart';
@@ -91,9 +92,15 @@ class _QuizScreenState extends State<QuizScreen>
       context,
       listen: false,
     ).currentUser;
+    final purchaseViewModel = Provider.of<PurchaseViewModel>(
+      context,
+      listen: false,
+    );
     final adUserId =
         currentUser?.providerUserId ?? currentUser?.id?.toString() ?? '';
-    if (adUserId.isNotEmpty && widget.episodeCode.isNotEmpty) {
+    if (!purchaseViewModel.skipsHintAds &&
+        adUserId.isNotEmpty &&
+        widget.episodeCode.isNotEmpty) {
       _adManager.loadAd(
         userId: adUserId,
         episodeCode: widget.episodeCode,
@@ -185,6 +192,15 @@ class _QuizScreenState extends State<QuizScreen>
   }
 
   Future<void> _handleHintPressed(QuizViewModel vm) async {
+    final purchaseViewModel = Provider.of<PurchaseViewModel>(
+      context,
+      listen: false,
+    );
+    if (purchaseViewModel.skipsHintAds) {
+      await _loadAndShowHint(vm);
+      return;
+    }
+
     final action = await _showHintAccessDialog();
     if (!mounted || action == null) return;
 
@@ -614,6 +630,7 @@ class _QuizStageBody extends StatelessWidget {
         final isKeyboardOpen = keyboardHeight > 0;
         final availableHeight = constraints.maxHeight - keyboardHeight - 12;
         final estimatedContentHeight = constraints.maxWidth + 168;
+        final removesAds = context.watch<PurchaseViewModel>().removesAds;
         final scale = isKeyboardOpen && availableHeight < estimatedContentHeight
             ? (availableHeight / estimatedContentHeight).clamp(0.58, 1.0)
             : 1.0;
@@ -636,7 +653,7 @@ class _QuizStageBody extends StatelessWidget {
                 ),
               ),
             ),
-            if (!isKeyboardOpen) ...[
+            if (!isKeyboardOpen && !removesAds) ...[
               const SizedBox(height: 8),
               const Expanded(child: _BannerAdReserve()),
             ],

--- a/thecode_pie_app/lib/presentation/screen/stage_select/stage_select_screen.dart
+++ b/thecode_pie_app/lib/presentation/screen/stage_select/stage_select_screen.dart
@@ -4,6 +4,7 @@ import 'package:thecode_pie_app/core/constants/app_colors.dart';
 import 'package:thecode_pie_app/core/constants/app_fonts.dart';
 import 'package:thecode_pie_app/presentation/component/premium_purchase_dialog.dart';
 import 'package:thecode_pie_app/presentation/component/retro_background.dart';
+import 'package:thecode_pie_app/presentation/purchase/purchase_view_model.dart';
 import 'package:thecode_pie_app/presentation/screen/quiz/quiz_screen_root.dart';
 import 'package:thecode_pie_app/presentation/screen/quiz/quiz_view_model.dart';
 import 'package:thecode_pie_app/providers/app_providers.dart';
@@ -34,7 +35,10 @@ class StageSelectScreen extends StatelessWidget {
     final unlockedThrough = rawUnlockedThrough > _totalStageCount
         ? _totalStageCount
         : rawUnlockedThrough;
-    final hasPremiumAccess = unlockedThrough > _freeStageCount;
+    final purchaseViewModel = context.watch<PurchaseViewModel>();
+    final hasPremiumAccess =
+        unlockedThrough > _freeStageCount ||
+        purchaseViewModel.unlocksPremiumStages;
 
     return Scaffold(
       body: Stack(
@@ -229,10 +233,10 @@ class _PremiumBanner extends StatelessWidget {
     final icon = hasPremiumAccess
         ? Icons.workspace_premium_rounded
         : Icons.lock_open_rounded;
-    final title = hasPremiumAccess ? '프리미엄 유저' : 'STAGE 21-50 해금';
+    final title = hasPremiumAccess ? '구매 항목 적용됨' : '프리미엄 패키지 구매하기';
     final subtitle = hasPremiumAccess
-        ? '프리미엄 패키지 구매 완료'
-        : '30개의 추가 스테이지 + 광고 제거';
+        ? '구매한 기능으로 플레이 중입니다'
+        : '힌트 광고 제거 + 배너 광고 제거 + STAGE 21-50 해금';
 
     return Material(
       color: background,

--- a/thecode_pie_app/lib/providers/app_providers.dart
+++ b/thecode_pie_app/lib/providers/app_providers.dart
@@ -2,6 +2,7 @@ import 'package:provider/provider.dart';
 import 'package:thecode_pie_app/quiz/data/repository/contents_repository.dart';
 
 import '../core/api/auth_api.dart';
+import '../core/purchase/purchase_api.dart';
 import '../core/storage/auth_storage.dart';
 import '../quiz/data/data_source/contents_data_source.dart';
 import '../auth/data/repository/auth_repository.dart';
@@ -18,6 +19,7 @@ import '../quiz/usecase/get_start_stage_usecase.dart';
 import '../quiz/usecase/has_hint_access_usecase.dart';
 import '../presentation/screen/auth/auth_view_model.dart';
 import '../presentation/screen/quiz/quiz_view_model.dart';
+import '../presentation/purchase/purchase_view_model.dart';
 
 /// 의존성 주입 설정
 class DependencyInjection {
@@ -80,6 +82,11 @@ class DependencyInjection {
     ),
     ChangeNotifierProvider<QuizViewModel>(
       create: (_) => _createQuizViewModel(),
+    ),
+    ChangeNotifierProvider<PurchaseViewModel>(
+      create: (_) =>
+          PurchaseViewModel(purchaseApi: PurchaseApi(_authRepository))
+            ..initialize(),
     ),
   ];
 }

--- a/thecode_pie_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/thecode_pie_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import audioplayers_darwin
 import flutter_secure_storage_macos
 import google_sign_in_ios
+import in_app_purchase_storekit
 import path_provider_foundation
 import shared_preferences_foundation
 import webview_flutter_wkwebview
@@ -16,6 +17,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
+  InAppPurchasePlugin.register(with: registry.registrar(forPlugin: "InAppPurchasePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))

--- a/thecode_pie_app/pubspec.lock
+++ b/thecode_pie_app/pubspec.lock
@@ -304,6 +304,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  in_app_purchase:
+    dependency: "direct main"
+    description:
+      name: in_app_purchase
+      sha256: "0e9510b80b0074e89ab0a8e0fc901439b779dc9ae575ab8d419253c6e1627716"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.0"
+  in_app_purchase_android:
+    dependency: transitive
+    description:
+      name: in_app_purchase_android
+      sha256: eb8f551039481d1b265f12fa54f5ab5dd4f13ec5444a468b85a3793517a37fda
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
+  in_app_purchase_platform_interface:
+    dependency: transitive
+    description:
+      name: in_app_purchase_platform_interface
+      sha256: "0b0076cac8ce4fa7048f01e76af8b123aeb6a7c4e0dea2a5206d6664454f3e36"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.1"
+  in_app_purchase_storekit:
+    dependency: transitive
+    description:
+      name: in_app_purchase_storekit
+      sha256: "47d63717270133fcfa1ff8e144f6aaf9d498fa3884de43e24909737da55aedd8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.10+1"
   js:
     dependency: transitive
     description:
@@ -312,6 +344,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.12.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -662,5 +702,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.35.1"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/thecode_pie_app/pubspec.yaml
+++ b/thecode_pie_app/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter_dotenv: ^5.1.0
   audioplayers: ^6.1.0
   google_mobile_ads: ^7.0.0
+  in_app_purchase: ^3.3.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## 작업 내용
  - in_app_purchase 기반 인앱결제 연결 추가
  - 상품 ID 3개 정의
      - premium_package
      - stage_unlock
      - remove_ads

  - 서버 entitlement API 연동
      - 권한 조회
      - Google Play 구매 검증 요청

  - 구매 다이얼로그를 실제 상품/가격/권한 상태 기반으로 동작하도록 변경
  - 구매 권한에 따라 앱 동작 반영
      - 힌트 광고 제거
      - 배너 광고 제거
      - STAGE 21-50 해금

  - debug 빌드 전용 테스트 구매 흐름 추가
      - 기존 구매 버튼 클릭
      - 테스트 구매 확인창
      - 예 선택 시 로컬 권한 적용
      - 첫 화면 왼쪽 하단 구매 초기화 버튼으로 테스트 권한 초기화